### PR TITLE
[ghost] Fix PVC creation

### DIFF
--- a/charts/stable/ghost/templates/common.yaml
+++ b/charts/stable/ghost/templates/common.yaml
@@ -3,13 +3,22 @@
 
 {{/* Append the hardcoded settings */}}
 {{- define "ghost.hardcodedValues" -}}
-  {{- if not .Values.persistence.content.enabled }}
+
 persistence:
+  {{- range $index, $persistence := .Values.persistence }}
+    {{- if $persistence.enabled }}
+      {{- printf "%v:" $index | nindent 2 }}
+      {{- toYaml $persistence | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if not .Values.persistence.content.enabled }}
   content:
-    enabled: true
+    enabled: "true"
     type: "emptyDir"
   {{- end }}
+  
 {{- end -}}
+
 {{- $_ := mergeOverwrite .Values (include "ghost.hardcodedValues" . | fromYaml) -}}
 
 {{/* Render the templates */}}


### PR DESCRIPTION
The current common file is not enough if the .Value contains persistence item is different than "content".
For exemple if you specify these following values, the persistence item shared will not be processed:
```YAML
persistence:
  content:
    enabled: false
    existingClaim: "pvc-nfs-ghost"
    mountPath: "/var/lib/ghost/content"
  shared:
    enabled: true
    mountPath: /shared
    type: emptyDir
```

<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! We will try to test and integrate the change as soon as we can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

All persistent items are computed in the hardcoded settings.

**Benefits**

We can specify none, only content, or several persistent items.

**Possible drawbacks**

None

**Applicable issues**

- fixes [ghost] Missing PVC #1358

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Title of the PR starts with chart name (e.g. `[home-assistant]`)
- [ ] Variables are documented in the README.md (this can be done with using our helm-docs wrapper `./hack/gen-helm-docs.sh stable <chart>`)

<!-- Keep in mind that if you are submitting a new chart, try to use our [common](https://github.com/k8s-at-home/charts/tree/master/charts/common) library as a dependency. This will help maintaining charts here and keep them consistent between each other -->
